### PR TITLE
Aegis Capability Upgrade Migration Guides

### DIFF
--- a/guides/composio_preservation.md
+++ b/guides/composio_preservation.md
@@ -1,0 +1,29 @@
+# Composio Preservation Guide
+Created by Jules
+
+## Current State
+Aegis integrates Composio for executing actions in third-party apps (Gmail, Calendar, etc.). It currently uses a manual "Tool Router" pattern (`aegis/executor.py`) to search for tools and a custom argument-filling step using Gemini. Most importantly, every Composio action is passed through `gate_action` in `aegis/gate.py` for GREEN/YELLOW/RED classification and biometric/verbal auth.
+
+## Target State
+Transition to the SDK's native tool-calling protocol for Composio while preserving the Aegis Security Gateway. Instead of a manual search-and-execute loop, Composio tools will be declared directly to Gemini. When Gemini calls a tool, the execution will be intercepted, sent to `gate.py` for authorization, and only then executed via the Composio client.
+
+## Migration Steps
+1. **Native Declarations**: Use the Composio SDK to export tool schemas in a format compatible with `google.genai.types.Tool`.
+2. **Intercept Tool Calls**:
+   - In `aegis/voice.py`, when `response.tool_call.function_calls` contains a Composio-prefixed tool (e.g., `GMAIL_...`):
+   - Extract the tool name and arguments.
+   - Pass them to `gate_action(simulated_action, context, tool_name=name, tool_args=args)`.
+3. **Handle Blocking Auth**:
+   - For RED actions, ensure the `request_remote_auth` poll is non-blocking to the main event loop.
+   - If auth fails or is denied, return a `function_response` to Gemini stating that the action was blocked for security.
+4. **Preserve User ID Context**:
+   - Ensure the `config.COMPOSIO_USER_ID` is correctly passed through the native tool executor to maintain multi-user isolation.
+
+## Files Changed
+- `aegis/executor.py`: Update or retire manual `search_and_execute` logic.
+- `aegis/voice.py`: Implement the native tool call interception and security wrapper.
+- `aegis/gate.py`: Ensure `classify_action` can handle direct tool names as hints (already partially implemented).
+
+## Gotchas
+- **Parallel Execution**: Native tool calls can be parallel. The Aegis Gateway must handle this by either queuing auth requests or prompting the user for a batch confirmation.
+- **Biometric Timeouts**: Biometric auth (Touch ID) has a 30-second timeout. If the user doesn't respond, the session must handle the tool failure gracefully without crashing the WebSocket.

--- a/guides/computer_use_integration.md
+++ b/guides/computer_use_integration.md
@@ -1,0 +1,30 @@
+# Computer Use Integration Guide
+Created by Jules
+
+## Current State
+Aegis uses manual `pyautogui` wrappers in `aegis/screen/` for screen control. Coordinate scaling is handled by a custom `_denormalize` function in `aegis/voice.py` to map from model outputs to a hardcoded 1470x956 resolution. Screenshots are captured and sent manually after every tool execution to update the model's visual context.
+
+## Target State
+Transition to the native **ComputerUse** tool provided by the SDK. This tool standardizes coordinate handling (normalized to 0-1000) and allows the model to interact with the OS more natively. Aegis will act as the "Client-Side Action Handler," executing native SDK actions (`click_at`, `type_text_at`, etc.) using its existing hardware-level executors.
+
+## Migration Steps
+1. **Declare Tool**: Add `Tool(computer_use=ComputerUse(environment=Environment.ENVIRONMENT_BROWSER))` to the `LiveConnectConfig` in `aegis/voice.py`.
+2. **Implement Action Mapping**:
+   - Update the `_receive_and_play_loop` in `aegis/voice.py` to parse `response.tool_call.computer_use`.
+   - Map native actions like `navigate` to `SCREEN_TYPE` or a new browser handler.
+   - Map `click_at`, `double_click_at`, etc., to the existing functions in `aegis/screen/cursor.py`.
+3. **Standardize Coordinates**:
+   - Update `_denormalize` to use the model's 0-1000 scale and dynamic screen dimensions instead of hardcoded values.
+4. **Auth Gating**:
+   - Wrap every native action in a call to `gate_action` to maintain the tiered security model (e.g., `click_at` should still be YELLOW).
+5. **Context Updates**:
+   - Instead of manual screenshots in the agent loop, provide the fresh screenshot in the `function_response` parts for the native tool.
+
+## Files Changed
+- `aegis/voice.py`: Update tool declarations and native tool call handler.
+- `aegis/screen_executor.py`: Potentially retire redundant manual tool definitions in favor of native SDK types.
+
+## Gotchas
+- **Coordinate Range**: The model expects 0-1000 for both X and Y. Ensure the `denormalize` logic correctly maps to the user's primary monitor resolution.
+- **Environment**: `Environment.ENVIRONMENT_BROWSER` is currently the supported environment type for most computer use models.
+- **Safety**: Native computer use allows for faster execution. Ensure the `YELLOW` confirmation logic in `gate.py` is non-blocking to the WebSocket heartbeats to prevent timeouts during user confirmation.

--- a/guides/live_api_migration.md
+++ b/guides/live_api_migration.md
@@ -1,0 +1,28 @@
+# Live API Migration Guide
+Created by Jules
+
+## Current State
+Aegis currently uses the **Gemini 2.0 Flash Native Audio** preview model (`gemini-2.0-flash-native-audio-preview-12-2025`). The bidirectional streaming implementation in `aegis/voice.py` uses a custom `pyaudio` loop but does not fully leverage the newer SDK signals for interruptions and turn boundaries.
+
+## Target State
+Upgrade to **Gemini 2.5 Flash Native Audio** (`gemini-2.5-flash-native-audio-latest`) or **Gemini 3 Flash** (`gemini-3-flash-preview`). The target implementation should utilize the standardized `google-genai` SDK patterns for low-latency bidirectional voice, ensuring natural barge-in handling and accurate turn completion signals.
+
+## Migration Steps
+1. **Update Model Constants**:
+   - Change `GEMINI_LIVE_MODEL` in `aegis/config.py` to the target model ID.
+2. **Refine Interruption Logic**:
+   - In `aegis/voice.py`, update the `_receive_and_play_loop` to check the `response.server_content.interrupted` flag.
+   - Immediately call `output_stream.stop()` and clear any pending audio buffers when `interrupted` is true to ensure natural barge-in behavior.
+3. **Handle Turn Completion**:
+   - Use the `turn_complete` signal from the server to accurately reset the `is_speaking` state and update the UI via `ws_server.broadcast`.
+4. **Modality Filtering**:
+   - Ensure the receive loop handles `model_turn` parts that contain thoughts or text (for thinking models) without attempting to play them as audio.
+
+## Files Changed
+- `aegis/config.py`: Update model ID and potentially regional endpoint settings.
+- `aegis/voice.py`: Refactor `_receive_and_play_loop` for interruption and turn handling.
+
+## Gotchas
+- **Session Limits**: Gemini Live sessions have duration limits (typically 15 minutes for audio-only). Implement reconnection logic using `session_resumption` if available in the SDK.
+- **Regional Endpoints**: Native audio capabilities are often tied to specific regional endpoints (e.g., `us-central1`). Ensure the client initialization matches the availability of the model.
+- **Sample Rates**: Ensure the `RECEIVE_SAMPLE_RATE` remains consistent with the model's output (usually 24000Hz PCM).

--- a/guides/thinking_config.md
+++ b/guides/thinking_config.md
@@ -1,0 +1,30 @@
+# Thinking Configuration Guide
+Created by Jules
+
+## Current State
+Aegis currently provides direct responses from Gemini without an explicit reasoning or "thinking" phase visible to the system or the user. This can lead to "vibe-coding" or unpredictable tool call sequences when performing complex Mac automation tasks.
+
+## Target State
+Enable the native **ThinkingConfig** in the Gemini Live API. This allows the model to produce "thoughts" (chain-of-thought reasoning) before generating a final response or tool call. These thoughts help the model navigate complex UI layouts and plan multi-step Composio workflows with higher accuracy.
+
+## Migration Steps
+1. **Enable Thinking**:
+   - In `aegis/voice.py`, update the `LiveConnectConfig` to include `thinking_config=ThinkingConfig(include_thoughts=True)`.
+2. **Handle Thought Parts**:
+   - Update the `_receive_and_play_loop` in `aegis/voice.py` to detect `part.thought` in the `model_turn`.
+   - Log these thoughts internally for debugging and system audit.
+3. **UI Propagation**:
+   - Update `aegis/ws_server.py` to support a new `thought` event.
+   - Broadcast the model's reasoning steps to the Aegis dashboard or Mac app UI so the user can see what the agent is "planning" (e.g., "I see the 'Send' button is at (500, 300), I will click it now.").
+4. **Model Selection**:
+   - Ensure the `GEMINI_LIVE_MODEL` is set to a version that supports `ThinkingConfig` (e.g., Gemini 3 models).
+
+## Files Changed
+- `aegis/voice.py`: Update config and receive loop to handle thought parts.
+- `aegis/ws_server.py`: Add broadcast support for thoughts.
+- `aegis/config.py`: Update to a thinking-capable model ID.
+
+## Gotchas
+- **Token Usage**: `ThinkingConfig` consumes additional tokens for the reasoning steps. Monitor usage to ensure it remains within budget.
+- **Latency**: While thinking improves quality, it adds a small delay before the first audio byte or tool call. Tune the system prompt to keep reasoning concise.
+- **Audio Exclusion**: Thoughts are textual and should never be processed by the `pyaudio` output stream.

--- a/guides/vad_and_speech_config.md
+++ b/guides/vad_and_speech_config.md
@@ -1,0 +1,30 @@
+# VAD and Speech Configuration Guide
+Created by Jules
+
+## Current State
+Aegis uses default Voice Activity Detection (VAD) settings and the "Aoede" voice. The current implementation in `aegis/voice.py` relies on basic SDK defaults, which may result in high latency for barge-ins or premature cut-offs in noisy environments. Audio sample rates are hardcoded to 16kHz (send) and 24kHz (receive).
+
+## Target State
+Optimize **AutomaticActivityDetection** and **SpeechConfig** for a more responsive and "human-like" interaction. This includes tuning sensitivity for speech detection and configuring prefix padding to prevent syllable clipping. The goal is to minimize the time between the user finishing their sentence and Aegis beginning its response.
+
+## Migration Steps
+1. **Configure VAD Sensitivity**:
+   - In `aegis/voice.py`, update `LiveConnectConfig` to include `realtime_input_config`.
+   - Set `start_of_speech_sensitivity` to `START_SENSITIVITY_HIGH` for faster trigger.
+   - Set `end_of_speech_sensitivity` to `END_SENSITIVITY_HIGH` to detect the end of turns more aggressively.
+2. **Tune Padding and Silence**:
+   - Configure `prefix_padding_ms` (e.g., 200ms) to ensure the beginning of user speech isn't lost.
+   - Set `silence_duration_ms` (e.g., 500ms) to balance responsiveness against accidental interruptions during pauses.
+3. **Voice Selection**:
+   - Update `PrebuiltVoiceConfig` to use specific high-fidelity voices like "Aoede" or "Fenrir" as available in the target model.
+4. **Dynamic Sample Rates**:
+   - Move sample rate configurations to `aegis/config.py` and ensure they match the requirements of the upgraded Native Audio models.
+
+## Files Changed
+- `aegis/voice.py`: Update `LiveConnectConfig` with detailed VAD and Speech settings.
+- `aegis/config.py`: Centralize audio parameters and voice names.
+
+## Gotchas
+- **Sensitivity Trade-offs**: High sensitivity can lead to "false starts" in noisy environments. Implement a software-level gate or noise suppression if needed.
+- **Voice Availability**: Not all voices are available in all regions or for all models. Verify voice support for the selected `GEMINI_LIVE_MODEL`.
+- **Latency**: Large `silence_duration_ms` values will make the agent feel sluggish. Keep this under 1000ms for a "live" feel.


### PR DESCRIPTION
I have completed the documentation task for planning the Aegis capability upgrade. 

**Summary of Changes:**
1. **Research:** Exhaustively analyzed the Aegis codebase and the latest Gemini API references, including native Computer Use, ThinkingConfig, and bidirectional streaming patterns.
2. **Strategy:** Formulated a roadmap to transition from manual `pyautogui` and custom tool routing to the SDK's native capabilities while preserving Aegis's core security tiers (GREEN/YELLOW/RED) and biometric auth flow.
3. **Documentation:** Created five detailed Markdown guides in the `guides/` directory:
    - `live_api_migration.md`: Model upgrade path and improved interruption handling.
    - `computer_use_integration.md`: Transitioning to native ComputerUse and coordinate standardization.
    - `composio_preservation.md`: Wrapping native tool calls with the security gateway.
    - `thinking_config.md`: Enabling reasoning steps and UI propagation.
    - `vad_and_speech_config.md`: Tuning VAD and Speech settings for low latency.

**Verification:**
- Confirmed all guides follow the requested structure and contain the "Created by Jules" header.
- Verified that no existing files were modified and no implementation code was written.
- Successfully ran existing backend tests to ensure repository stability.
- Completed code review and memory recording.

---
*PR created automatically by Jules for task [15300790019022322952](https://jules.google.com/task/15300790019022322952) started by @harshitsinghbhandari*