### PR TITLE
docs: create comprehensive Aegis hackathon documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,42 @@
+# Aegis Architecture and System Design
+
+## Philosophy and Core Design Decisions
+Aegis was designed from the ground up to be a **local-first, cloud-secured** AI agent. It needs the low-latency responsiveness of a local application to monitor the screen continuously, but it requires the robust security of a cloud-based out-of-band authentication system to enforce its Three-Tier Security Model.
+
+### Why Local-First?
+An agent capable of "Native ComputerUse" (moving the mouse, taking screenshots, clicking buttons) must reside on the host machine. Streaming continuous desktop frames to a generic web server is not only a privacy nightmare but also introduces unacceptable latency.
+Aegis runs a local Python helper server (`voice.py`) that captures the screen and audio locally. It manages its own state machine (`LISTENING/THINKING/EXECUTING/BUSY`) and handles execution locally using tools like `pyautogui` and `mss`.
+
+### Why Native ComputerUse over Composio?
+Initially, Aegis relied on Composio toolkits (like the Gmail or GitHub integrations). However, a pivot was made to pure **Native ComputerUse**. By utilizing `screen_executor.py` and the Gemini Live API with high-resolution screenshot crops (`cursor_crop`, `get_annotated_elements`), Aegis interacts with the UI directly. This removes the need for brittle third-party integrations or OAuth tokens, allowing Aegis to navigate any app that is visible on the screen, just like a human. It's a true "Trusted Pilot."
+
+## System Components
+
+### 1. Local Mac Agent (`packages/aegis/`)
+This is the heart of Aegis, running entirely on the user's macOS device.
+
+*   **`interfaces/voice.py`**: Handles real-time duplex streaming to the Gemini Live API. It captures audio input and continuously sends delta-based screenshot streams (every 2-3 seconds) to the LLM, giving it persistent visual context.
+*   **`agent/classifier.py`**: The "brain" of the trust boundary. It uses a secondary LLM call (Gemini 2.5 Flash) to parse an intent and classify it as GREEN, YELLOW, or RED based on irreversibility.
+*   **`agent/gate.py`**: The Auth Router. It takes the output from the classifier and enforces the rules. If GREEN, it executes immediately. If YELLOW, it requests verbal confirmation. If RED, it blocks execution, captures the visual context, and pings the Cloud Backend for remote biometric authentication, falling back to local Touch ID if necessary.
+*   **`runtime/screen_executor.py`**: The native execution engine. Maps commands like `cursor_click` or `keyboard_type` to actual OS-level commands.
+*   **`interfaces/ws_server.py`**: The Local WebSocket Server.
+
+### 2. Local Communication: Why WebSockets?
+To provide real-time UI feedback (like state changes, waveform data, and action logs) without the overhead of HTTP polling, Aegis uses a local WebSocket server (`ws://localhost:8765`). The Mac PWA connects to this local server. This architecture guarantees zero-latency UI updates when Aegis transitions between `LISTENING` and `EXECUTING` states, ensuring the user always knows what the agent is doing.
+
+### 3. The Frontends (React PWAs)
+Aegis uses Progressive Web Apps (PWAs) instead of native applications.
+*   **Mac PWA**: The local user interface showing real-time agent state, waveforms, and live action logs. It sends Start/Stop signals to the local helper server.
+*   **Dashboard PWA**: The central hub for the user to view historical audit logs via Server-Sent Events (SSE) from the backend.
+*   **Mobile PWA**: The companion app used for out-of-band biometric authentication. It registers a Face ID credential using the WebAuthn standard and polls the backend for pending "RED" action requests.
+
+### 4. Cloud Run and Firestore Backend
+The GCP Backend (`services/backend/run_backend.py`) is built with FastAPI and deployed on Google Cloud Run.
+
+*   **Why Cloud Run?**: Serverless architecture allows the backend to scale to zero when not in use, keeping costs low while providing instantaneous spin-up times for authentication handshakes.
+*   **Why Firestore?**: Firestore's real-time capabilities (`on_snapshot`) and NoSQL structure are perfect for Aegis. It handles active session status, audit logging, WebAuthn credentials, and most crucially, real-time polling for "auth_requests" (the RED tier biometric challenges).
+
+## Tradeoffs Made
+1.  **Latency vs. Security**: The secondary LLM call in `classifier.py` adds ~500-1000ms of latency before executing any action. This is a deliberate tradeoff: sacrificing absolute speed for absolute safety.
+2.  **PWA vs. Native Mobile App**: A native iOS app could receive silent push notifications (APNs) faster. However, a PWA using WebAuthn allows for immediate cross-platform deployment without App Store review hurdles, while still securely utilizing the device's secure enclave (Face ID).
+3.  **Local Vision vs. Cloud Vision Processing**: Sending screenshots continuously to Gemini consumes massive bandwidth and tokens. To mitigate this, Aegis uses local `mss` captures and `pyautogui` for execution, but relies on the cloud LLM to interpret the frames. Local OCR is also used (`aegis.perception.screen.ocr`) to supplement the cloud vision model, creating a hybrid approach that balances cloud intelligence with local precision.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Aegis Changelog
+
+This document summarizes the major version history of Aegis during the hackathon, based on the repository's git tags.
+
+### [v3.0.0-navigation-stable] - Latest Stable Release
+*   **Feature:** Reliable navigation via OCR + `label_id` clicking. The system successfully stabilizes the Native ComputerUse capabilities using purely visual analysis.
+
+### [v2.8.0-refactor-monorepo] - Monorepo Structure
+*   **Refactor:** The repository was refactored into a scalable monorepo structure utilizing absolute imports and centralized configs (`apps/`, `services/`, `packages/`, `configs/`, `cmd/`, `docs/`, `scripts/`, `env/`). Final sanity checks and frontend build confirmations were added.
+
+### [v2.7.0-screen-agent] - The Pivot to Native ComputerUse
+*   **Feature:** Complete pivot to a screen-only architecture. Composio toolkits were removed in favor of native, continuous visual monitoring and UI interaction.
+*   **Feature:** Multi-step navigation and complex task execution working purely through visual means.
+
+### [v2.6.0-live-vision] - Gemini Live Video Pipeline
+*   **Feature:** Implemented an automatic ~2-second delta screenshot feed directly into the Gemini Live session, providing the agent with persistent visual context. Full pipeline verified end-to-end.
+
+### [v2.5.1-pin-auth-verified] & [v2.5.0-pin-auth] - Fallback Auth System
+*   **Feature:** Added a PIN authentication gate as a fallback mechanism for all PWAs and backend endpoints. Registered securely in Firestore.
+
+### [v2.4.0-reproducibility] & [v2.3.0-docs] - Documentation & Launch Prep
+*   **Docs:** Added `REPRODUCIBILITY.md`, security roadmap, updated `README.md`, and finalized architecture diagrams. Repository prepared for public viewing.
+
+### [v2.2.0-public-launch] & [v2.1.0-landing-page] - Public Deployment
+*   **Feature:** Deployed the Landing Page and Setup Page to `aegis.projectalpha.in`. System is now accessible for public demo.
+
+### [v2.0.0-multi-user] - Architecture Overhaul
+*   **Feature:** Migrated to a multi-user architecture. Firestore schemas are now scoped securely per user. Added `X-User-ID` headers across all backend endpoints. Added `install.sh` for easy setup.
+
+### [v1.9.0-cicd] - Deployment Automation
+*   **Feature:** Implemented prebuilt Docker images and CI/CD pipelines for deployment.
+
+### [v1.7.2-schema-aware], [v1.7.1-seven-toolkits], [v1.7.0-seven-toolkits] - The API Integration Era
+*   **Feature:** Implemented and stabilized 7 Composio toolkits (Gmail, Calendar, Docs, Sheets, Slides, Tasks, GitHub). Added schema-aware argument filling. (Note: These features were later deprecated in `v2.7.0` in favor of Native ComputerUse).
+
+### [v1.6.0-faceid-working] - Biometric Auth Success
+*   **Feature:** Full end-to-end working demonstration of Face ID out-of-band authentication on the iPhone companion app for "RED" tier actions.
+
+### [v1.5.0-pwas-working], [v1.4.0-all-pwas-live], [v1.3.0-pwa-pivot] - The Move to PWAs
+*   **Feature:** Deployed macOS PWA and Mobile PWA. All four services (Backend, Dashboard, Mac App, Mobile App) are now live. Shelved native macOS/iOS apps in favor of cross-platform Progressive Web Apps.
+
+### [v1.0.0-websocket] - Real-time Communication
+*   **Feature:** Implemented a local WebSocket server (`ws://localhost:8765`) to stream real-time UI events, state changes, and audio waveforms from the Python agent to the Mac PWA.
+
+### [v0.8.0-aegis] - Rebranding
+*   **Feature:** Officially rebranded the project to "Aegis" — The Trusted Pilot for the Agentic Era.
+
+### [v0.7.0-domains-live], [v0.6.0-domain], [v0.5.0-all-tiers] - Core Security Model Verification
+*   **Feature:** All three tiers (GREEN: Silent, YELLOW: Confirm, RED: Biometric) are fully operational and verified end-to-end.
+
+### [v0.4.0-full-stack] & [v0.3.0-dashboard] - Dashboard & Cloud Run
+*   **Feature:** Deployed the real-time Dashboard PWA and backend to GCP Cloud Run.
+
+### [v0.2.0-gcp] & [v0.1.0-core] - Initial Cloud Architecture
+*   **Feature:** Configured core settings and successfully deployed the initial backend structure to Google Cloud Platform.

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,75 @@
+# Aegis Demo Guide for Judges
+
+Welcome to the Aegis Demo! This guide is designed to help you experience the core value proposition of Aegis: **Graduated Trust in Autonomous Agents**.
+
+Aegis is not just a chatbot; it's a "Trusted Pilot" for your Mac that enforces a strict security boundary by classifying every action into three risk tiers: Silent (Green), Confirm (Yellow), and Biometric (Red).
+
+By following these steps, you will see how Aegis balances autonomy with safety.
+
+---
+
+## Prerequisites
+Before you begin the demo, please ensure the following:
+
+1.  **Local Helper Server Running:** The Python backend must be running on your Mac. You should see `ws://localhost:8765` active in your terminal logs.
+2.  **Mac PWA Open:** The primary interface should be open in a browser (`https://aegismac.projectalpha.in`) and the microphone should be active. The interface should show the "Listening" state.
+3.  **Mobile Companion App Installed:** You must have the Aegis Companion App installed as a PWA on your iPhone (`https://aegismobile.projectalpha.in`), and you must have completed the "Register Face ID" step. The app should be open or running in the background.
+4.  **Dashboard Open:** Keep the Dashboard (`https://aegisdashboard.projectalpha.in`) open on a secondary monitor or split-screen to watch the real-time Server-Sent Events (SSE) audit log.
+
+---
+
+## Demo Script
+
+### 1. The GREEN Action (Silent Execution)
+Green actions are safe, read-only, or navigational actions. They execute silently and instantly, demonstrating Aegis's autonomy.
+
+*   **You say:** *"Aegis, take a screenshot and tell me what the top headline is on the current webpage."*
+*   **What to expect on your Mac:**
+    *   Aegis will transition to the `THINKING` state.
+    *   It will execute a `screen_capture` or `screen_read` tool silently.
+    *   Aegis will respond verbally with the information.
+*   **What to expect on the Dashboard:**
+    *   A new log entry will appear with a green badge: `[GREEN] Action: Read screen | Tool: screen_read`
+
+### 2. The YELLOW Action (Voice Confirmation)
+Yellow actions are state-mutating but non-destructive (e.g., clicking a non-critical button, typing a draft). They require explicit verbal confirmation.
+
+*   **You say:** *"Aegis, click the 'Sign In' button on the top right."*
+*   **What to expect on your Mac:**
+    *   Aegis will transition to the `THINKING` state.
+    *   Instead of immediately executing the click, Aegis will pause and ask you: *"I am about to click the 'Sign In' button. Is that okay?"*
+*   **You reply:** *"Yes, proceed."*
+*   **What happens next:**
+    *   Aegis executes the `cursor_click` (or `click_by_word`) tool. You will see your mouse cursor move and click the button.
+*   **What to expect on the Dashboard:**
+    *   A log entry will appear with a yellow badge: `[YELLOW] Action: Click Sign In | Tool: cursor_click | Confirmed: True`
+
+### 3. The RED Action (Biometric Authentication)
+Red actions are irreversible, destructive, or highly sensitive (e.g., sending an email, deleting a file). These *cannot* be authorized by voice alone; they require an out-of-band biometric challenge.
+
+*   **You say:** *"Aegis, open Terminal and forcefully delete the `downloads` folder."* (Or any similar destructive command using `keyboard_type_sensitive`).
+*   **What to expect on your Mac:**
+    *   Aegis transitions to the `THINKING` state.
+    *   Aegis will say: *"This action requires biometric authentication. Please check your mobile device."*
+    *   The Mac PWA will display a "Waiting for Authentication" prompt, showing a crop of the screen where the action is proposed.
+*   **What to expect on your iPhone:**
+    *   The Aegis Mobile App will display an **Auth Request**.
+    *   It will show the proposed action ("Delete downloads folder") and the requested tool (`keyboard_type_sensitive`).
+    *   You must tap "Approve."
+    *   Face ID (or Touch ID) will prompt you for cryptographic verification via WebAuthn.
+*   **What happens next:**
+    *   Once Face ID succeeds, the iPhone sends the signed payload to the Cloud Run backend.
+    *   The backend validates the signature and updates the Firestore document.
+    *   The local Mac agent, polling the backend, sees the approval and immediately executes the action.
+*   **What to expect on the Dashboard:**
+    *   A log entry will appear with a red badge: `[RED] Action: Delete downloads | Tool: keyboard_type_sensitive | Auth_Used: True`
+
+---
+
+## Known Limitations & Sandbox Notes
+
+While reviewing Aegis, please keep the following in mind:
+
+*   **Gmail / Google OAuth Restriction:** If you ask Aegis to read your Gmail, it will fail. This is **not a bug** in Aegis. Because Aegis is an unverified app in the Google Cloud Console, Google's strict OAuth policies block read-access to sensitive scopes (like `https://www.googleapis.com/auth/gmail.readonly`) for anyone other than the developer's test accounts. Aegis is aware of this and handles the rejection gracefully.
+*   **Local Screen Context:** Aegis uses the Gemini Live API for voice interaction but relies on `mss` (a fast, cross-platform screenshot library) and `pyautogui` for execution, rather than sending continuous, raw desktop streams to the cloud. This hybrid approach saves massive bandwidth but means Aegis sometimes needs to "look closely" (`screen_crop` or `get_annotated_elements`) to find exact clickable coordinates.
+*   **Composio Migration:** Earlier versions of Aegis relied on Composio toolkits for API integrations. We pivoted to a pure **Native ComputerUse** model (visual processing + native clicks/typing) because it is far more secure and realistic for a general-purpose agent. You may still see some legacy Composio documentation in the repository, but the current demo relies entirely on native screen control.

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -1,0 +1,27 @@
+# Aegis: The Trusted Pilot for the Agentic Era
+
+## The Problem
+Autonomous AI agents are incredibly powerful, but they lack a fundamental concept: a **trust boundary**. Today's agents operate in a binary state: they are either entirely autonomous (which is terrifying when they have full access to your machine) or entirely manual (which defeats the purpose of an agent).
+
+If you ask an AI to "summarize my emails," you want it to act quickly and silently. But if that same AI decides to "delete my repository" or "send a legally binding email," you want an immediate, hard stop. You want a way to say, *"Yes, I authorize this specific action."*
+
+Without this trust boundary, users will never adopt true autonomous desktop agents. The risk is simply too high.
+
+## The Core Insight: Graduated Trust
+The solution is not to cripple the AI, but to introduce **Graduated Trust**. Aegis categorizes every proposed action into a three-tier security model:
+
+*   🟢 **Silent (Green)**: Safe, read-only, or navigational actions (e.g., scrolling, reading screen text, clicking a link). These execute silently and instantly.
+*   🟡 **Confirm (Yellow)**: State-mutating but non-destructive actions (e.g., typing an email draft, clicking "Submit"). These require verbal confirmation via the Gemini Live audio stream.
+*   🔴 **Biometric (Red)**: Irreversible or highly sensitive actions (e.g., clicking "Send," entering passwords, deleting files). These trigger an out-of-band cryptographic challenge requiring Native Touch ID on the Mac or Face ID on a companion iPhone app (via WebAuthn).
+
+This isn't just a heuristic; it's a fundamental architectural shift. Aegis evaluates the *irreversibility* of the intent, not just the tool being used.
+
+## What Makes Aegis Different?
+Every other agent submission focuses purely on *capability*—how many APIs they can connect, or how fast they can generate code. Aegis focuses on **safety and human-in-the-loop control**.
+
+1.  **Native ComputerUse + Vision**: Aegis doesn't rely on brittle DOM scraping. It uses a high-speed duplex stream of audio and video with the Gemini Live API, streaming screenshots every few seconds, allowing it to "see" exactly what you see.
+2.  **Out-of-Band Auth**: If the agent is compromised on the desktop, the authentication prompt is sent to a secondary device (your iPhone) via a WebSocket and Cloud Run backend. The Face ID approval is cryptographically signed and verified before the action executes.
+3.  **Local-First, Cloud-Secured**: The agent runs locally on your Mac, ensuring screen data never unnecessarily leaves your machine except to the LLM. The cloud backend exists solely to broker secure biometric handshakes.
+
+## Future Vision
+Aegis is the foundation for an OS-level "Trust Gateway." In the future, operating systems won't just ask for microphone or camera permissions; they will ask for "Agentic Action" permissions based on risk tiers. Aegis demonstrates how this OS-level trust boundary will work, enabling humans to unleash AI agents on their personal computers without fear of irreversible mistakes.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,96 @@
+# Aegis Full Setup Guide
+
+This guide walks you through the complete process of setting up Aegis on your local macOS environment. You will be configuring the local agent, the cloud backend, and connecting the companion mobile app.
+
+## Prerequisites
+Before you begin, ensure you have the following installed on your machine:
+*   **macOS** (This is required for native ComputerUse and local Touch ID support.)
+*   **Python 3.10 or 3.11** (`python --version`)
+*   **Node.js 18+ and npm** (If you intend to run the PWAs locally.)
+*   **Google Cloud CLI (`gcloud`)** (If you are deploying the backend yourself.)
+*   **A Google Gemini API Key** (Accessible from Google AI Studio.)
+
+---
+
+## 1. Local Agent Setup
+
+### Automatic Setup (Recommended)
+1.  Visit the Aegis Setup Page: [https://aegis.projectalpha.in/setup](https://aegis.projectalpha.in/setup)
+2.  Follow the prompts to create your profile, input your `GOOGLE_API_KEY`, and create your `AEGIS_PIN`.
+3.  The setup page will generate an installation command for your terminal. Run it in the root of the repository.
+
+### Manual Setup
+If you prefer not to use the automated script, perform the following steps:
+
+1.  **Clone the Repository:**
+    ```bash
+    git clone https://github.com/[your-repo]/aegis.git
+    cd aegis
+    ```
+
+2.  **Environment Variables:**
+    Copy the `.env.example` file and configure your keys.
+    ```bash
+    cp env/.env.example .env
+    ```
+    Open `.env` and fill in:
+    *   `GOOGLE_API_KEY`: Your Gemini API key.
+    *   `USER_ID`: A unique identifier (e.g., your username).
+    *   `AEGIS_PIN`: A secure PIN used for fallback authentication.
+    *   `BACKEND_URL`: Leave as default (https://apiaegis.projectalpha.in) or your deployed Cloud Run URL.
+
+3.  **Install Python Dependencies:**
+    Aegis requires specific dependencies, including `pyautogui` and `mss` for screen capture, and `google-genai` for the Gemini API.
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+4.  **Start the Local Helper Server:**
+    The Python helper server handles audio, video streaming, and native computer execution.
+    ```bash
+    PYTHONPATH=. python3 cmd/agent/run_agent.py
+    ```
+
+---
+
+## 2. Connect the Interfaces
+
+1.  **Mac Control Interface:**
+    Open the Mac PWA in Chrome or Edge: [https://aegismac.projectalpha.in](https://aegismac.projectalpha.in)
+    *   This interface communicates with `run_agent.py` via WebSockets (`ws://localhost:8765`).
+    *   Click "Start Aegis" and allow microphone permissions. You should see the audio waveform react to your voice.
+
+2.  **Dashboard:**
+    Open [https://aegisdashboard.projectalpha.in](https://aegisdashboard.projectalpha.in)
+    *   Enter your `USER_ID`. You will see a real-time stream of audit logs (SSE) as Aegis executes actions on your machine.
+
+3.  **Mobile Companion App (Crucial for RED Actions):**
+    Open [https://aegismobile.projectalpha.in](https://aegismobile.projectalpha.in) **on your iPhone Safari**.
+    *   Tap the Share icon and select "Add to Home Screen" to install it as a PWA.
+    *   Open the newly installed app.
+    *   Enter your `USER_ID`.
+    *   Click "Register Face ID" to securely bind your device using WebAuthn.
+    *   Leave the app open or in the background to receive Red Action auth requests.
+
+---
+
+## 3. Verify End-to-End Operation
+
+Now that everything is running, test the Three-Tier Security Model:
+
+1.  **Green Action (Silent Execution):**
+    *   Say aloud to the Mac interface: *"Aegis, take a screenshot and describe what you see."*
+    *   *Expected behavior:* The agent should read the screen and reply verbally. No prompts will appear.
+2.  **Yellow Action (Verbal Confirmation):**
+    *   Say aloud: *"Open a new tab and search for the weather."*
+    *   *Expected behavior:* Aegis will classify this as a UI interaction. It will say, "I am about to open a new tab. Is that okay?" Reply "Yes." It will then execute the action.
+3.  **Red Action (Biometric Verification):**
+    *   Say aloud: *"Aegis, delete the `requirements.txt` file."*
+    *   *Expected behavior:* Aegis will classify this as a destructive action. The execution will pause. Your iPhone will display an Auth Request. You must use Face ID on your iPhone to approve it. If approved, the file will be deleted. If denied (or if you don't respond), Aegis will say, "Authentication failed. Action blocked."
+
+## Common Errors & Troubleshooting
+
+*   **"WebSocket Connection Failed" in Mac PWA:** Ensure `cmd/agent/run_agent.py` is running locally. Check terminal logs for port binding errors (`Address already in use`).
+*   **Screen Actions Not Working (macOS):** Ensure your Terminal (or VS Code) has **Screen Recording** and **Accessibility** permissions enabled in `System Settings > Privacy & Security`.
+*   **Face ID Registration Fails:** Ensure you are accessing the Mobile PWA via `https://` on Safari, and that you have added the site to your Home Screen.
+*   **"Authentication failed" immediately:** The backend URL might be misconfigured in your `.env`. Verify it points to the correct deployed backend.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,199 @@
+# Aegis API Reference
+
+The Aegis backend is built using FastAPI. It handles routing auth requests, maintaining session state, streaming audit logs, and WebAuthn registration/verification.
+
+## Base URL
+The backend is typically deployed at: `https://apiaegis.projectalpha.in`
+
+## Authentication
+Most endpoints require a user to be identified. This is done via an HTTP header:
+*   `X-User-ID`: The unique string identifier for the user (e.g., `harshitbhandari0318`).
+
+---
+
+## 1. Action & Audit Endpoints
+
+### `POST /action`
+Logs an action executed (or blocked) by the local Mac agent.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Body:**
+    ```json
+    {
+      "timestamp": "2023-10-27T10:00:00Z",
+      "action": "Read screen",
+      "tier": "GREEN",
+      "tool": "screen_read",
+      "arguments": {},
+      "auth_used": false,
+      "confirmed_verbally": false,
+      "blocked": false,
+      "success": true,
+      "output": "The text on screen says...",
+      "error": null,
+      "duration_ms": 1250,
+      "device": "harshit-macbook"
+    }
+    ```
+*   **Response:** `200 OK` `{"status": "logged", "id": "<doc_id>"}`
+
+### `GET /audit/stream`
+A Server-Sent Events (SSE) endpoint used by the Dashboard PWA to stream logs in real-time.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Response:** `text/event-stream` stream yielding JSON strings.
+
+### `GET /audit/log`
+Retrieves historical audit logs.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Query Params:** `tier` (optional, filter by GREEN/YELLOW/RED), `limit` (default 50)
+*   **Response:** List of log objects.
+
+---
+
+## 2. Authentication Flow Endpoints (The "Gate")
+
+### `POST /auth/request`
+Called by the local agent when a RED action is intercepted. Creates a pending auth request.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Body:**
+    ```json
+    {
+      "action": "Delete downloads folder",
+      "tier": "RED",
+      "reason": "Destructive command",
+      "speak": "I need to check something before I do that.",
+      "tool": "keyboard_type_sensitive",
+      "arguments": {},
+      "device": "harshit-macbook",
+      "visual_context": {
+         "base64_image": "iVBORw0KG...",
+         "mime_type": "image/jpeg",
+         "action_description": "Delete downloads folder",
+         "element_label": "keyboard_type_sensitive"
+      }
+    }
+    ```
+*   **Response:** `200 OK` `{"status": "requested", "request_id": "<uuid>"}`
+
+### `GET /auth/status/{request_id}`
+Called by the local agent to poll for the result of an auth request.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Response:**
+    ```json
+    {
+      "request_id": "<uuid>",
+      "status": "pending" | "approved" | "denied" | "expired",
+      "resolved_at": "timestamp or null"
+    }
+    ```
+
+### `GET /auth/pending`
+Called by the Mobile PWA to check if there are any pending RED actions requiring biometric approval.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Query Params:** `device` (optional)
+*   **Response:** List of pending request objects including `visual_context`.
+
+### `POST /auth/approve/{request_id}`
+(Legacy/Fallback) Endpoint to manually approve/deny a request without WebAuthn.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Body:** `{"approved": true}`
+*   **Response:** `200 OK`
+
+---
+
+## 3. WebAuthn Endpoints
+
+These endpoints manage the FIDO2/WebAuthn lifecycle for the iPhone Companion App.
+
+### `POST /webauthn/register/options`
+Step 1 of registering Face ID. Returns challenge options.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Response:** JSON PublicKeyCredentialCreationOptions.
+
+### `POST /webauthn/register/verify`
+Step 2 of registering. Verifies the assertion from the device and saves the public key to Firestore.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Body:** `{"credential": { ... }}`
+*   **Response:** `{"verified": true}`
+
+### `POST /webauthn/auth/options`
+Step 1 of authenticating a specific pending request.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Response:** JSON PublicKeyCredentialRequestOptions.
+
+### `POST /webauthn/auth/verify`
+Step 2 of authenticating. Verifies the signed payload using the stored public key and approves the associated `request_id`.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Body:** `{"credential": { ... }, "request_id": "<uuid>"}`
+*   **Response:** `{"verified": true}`
+
+### `GET /webauthn/registered/{user_id_path}`
+Checks if the user has a registered Face ID credential.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Response:** `{"registered": true|false}`
+
+---
+
+## 4. PIN Fallback Authentication
+
+### `POST /auth/register-pin`
+Registers a fallback PIN for the user. (No `X-User-ID` header required, payload contains ID).
+
+*   **Body:** `{"user_id": "harshitbhandari0318", "pin": "1234"}`
+*   **Response:** `{"success": true}`
+
+### `POST /auth/verify-pin`
+Verifies the PIN (rate-limited to 5/minute).
+
+*   **Body:** `{"user_id": "harshitbhandari0318", "pin": "1234"}`
+*   **Response:** `{"success": true, "user_id": "harshitbhandari0318"}`
+
+---
+
+## 5. Session & Device Management
+
+### `POST /device/register`
+Registers an FCM (Firebase Cloud Messaging) token for the mobile app (used for push notifications if configured).
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Body:** `{"device_id": "iphone", "fcm_token": "..."}`
+*   **Response:** `{"status": "registered"}`
+
+### `GET /session/status`
+Checks if the local Mac agent is currently active.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Response:** `{"is_active": true|false}`
+
+### `POST /session/status`
+Updates the active status of the local agent.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Body:** `{"is_active": true}`
+*   **Response:** `{"status": "updated", "is_active": true}`
+
+### `POST /session/stop`
+Forces the session to stop.
+
+*   **Headers:** `X-User-ID: <string>`
+*   **Response:** `{"status": "stopped"}`
+
+---
+
+## 6. System
+
+### `GET /health`
+Returns system health, including the status of dependencies like Firestore.
+
+*   **Response:** `{"status": "ok", "timestamp": "...", "dependencies": {"firestore": "ok"}}`

--- a/docs/composio-tools.md
+++ b/docs/composio-tools.md
@@ -1,0 +1,60 @@
+# Legacy: Composio Toolkits Integration
+
+*Note: As of tag `v2.7.0`, Aegis pivoted away from Composio in favor of Native ComputerUse (vision + `pyautogui`). However, this document preserves the architecture and reasoning behind the original 7 toolkits used during the `v1.7.1` milestone, as they perfectly illustrate the Graduated Trust Security Model applied to APIs.*
+
+During its initial development, Aegis integrated with **Composio**, a platform that provides unified toolkits for connecting AI agents to third-party services. Aegis utilized 7 core toolkits:
+
+1.  **Gmail**
+2.  **Google Calendar**
+3.  **Google Docs**
+4.  **Google Sheets**
+5.  **Google Slides**
+6.  **Google Tasks**
+7.  **GitHub**
+
+## The Tier Mapping Logic
+
+Even when using API calls instead of screen clicks, Aegis enforced the Three-Tier Security Model. The classifier (`packages/aegis/agent/classifier.py` in older commits) intercepted the `composio_execute` tool call, evaluated the *intent* of the specific action within the toolkit, and assigned a risk tier.
+
+Here is how the 7 toolkits and their actions mapped to the tiers:
+
+### 🟢 GREEN (Silent Execution)
+**Criteria:** The API call is `GET` or purely read-only. It fetches data but alters nothing on the server.
+
+*   **Gmail:** `GMAIL_GET_MESSAGE`, `GMAIL_LIST_THREADS`, `GMAIL_SEARCH`
+*   **Calendar:** `CALENDAR_GET_EVENT`, `CALENDAR_LIST_EVENTS`
+*   **Docs/Sheets/Slides:** `GOOGLE_DOCS_READ`, `GOOGLE_SHEETS_GET_VALUES`
+*   **Tasks:** `GOOGLE_TASKS_LIST`
+*   **GitHub:** `GITHUB_GET_REPO`, `GITHUB_LIST_ISSUES`, `GITHUB_GET_PULL_REQUEST`
+
+**Why?** Reading a calendar event or viewing a GitHub issue poses no risk of data loss or unauthorized communication. Aegis could execute these autonomously without interrupting the user.
+
+### 🟡 YELLOW (Voice Confirmation)
+**Criteria:** The API call is a `POST`/`PUT`/`PATCH` that mutates state, but the impact is internal, non-destructive, or easily reversible.
+
+*   **Gmail:** `GMAIL_CREATE_DRAFT` (Creating a draft doesn't send it, so it's safe but mutates state).
+*   **Calendar:** `CALENDAR_CREATE_EVENT`, `CALENDAR_UPDATE_EVENT`
+*   **Docs/Sheets/Slides:** `GOOGLE_DOCS_CREATE`, `GOOGLE_SHEETS_UPDATE_VALUES`
+*   **Tasks:** `GOOGLE_TASKS_INSERT`, `GOOGLE_TASKS_UPDATE`
+*   **GitHub:** `GITHUB_CREATE_ISSUE`, `GITHUB_ISSUE_COMMENT`
+
+**Why?** Creating a calendar event or drafting an email changes the user's data. Aegis requires the user to say "Yes, proceed" before making the API call to ensure it hasn't hallucinated a meeting time or issue description.
+
+### 🔴 RED (Biometric Authentication)
+**Criteria:** The API call is highly sensitive, sends communication to external parties, or is destructive (`DELETE`).
+
+*   **Gmail:** `GMAIL_SEND_MESSAGE`, `GMAIL_TRASH_MESSAGE`
+*   **Calendar:** `CALENDAR_DELETE_EVENT`
+*   **GitHub:** `GITHUB_MERGE_PULL_REQUEST`, `GITHUB_DELETE_REPO`
+
+**Why?** Sending an email cannot be undone. Merging a PR affects a codebase permanently. Deleting an event might confuse invitees. These actions were hard-blocked and triggered an out-of-band Face ID challenge on the companion mobile app.
+
+## Why We Moved Away from Composio
+
+While the mapping above worked perfectly to demonstrate the security model, it had limitations for a truly general-purpose desktop agent:
+
+1.  **OAuth Friction:** Users had to authenticate Composio with every individual service (Google, GitHub, Slack, etc.).
+2.  **Google App Verification:** As an unverified app, getting read access to Gmail via OAuth is nearly impossible for non-test users.
+3.  **Visual Grounding:** When an agent uses an API in the background, the user doesn't see what's happening on their screen. This breaks trust.
+
+By moving to **Native ComputerUse** (vision + native cursor clicks), Aegis now bypasses OAuth entirely. It interacts with the web browser exactly like a human does, providing visual proof of its actions while still strictly enforcing the GREEN/YELLOW/RED trust boundaries.

--- a/docs/gcp-deployment.md
+++ b/docs/gcp-deployment.md
@@ -1,0 +1,75 @@
+# Aegis GCP Deployment Guide
+
+Aegis relies on Google Cloud Platform (GCP) for its cloud backend. This backend is crucial for enabling out-of-band biometric authentication via WebAuthn and for providing real-time audit logs to the web dashboard.
+
+## 1. Why GCP?
+
+The architecture leverages two specific GCP services:
+
+*   **Cloud Run:** A fully managed compute platform that automatically scales stateless containers. Because Aegis only needs the backend intermittently (when a RED action requires authentication or when a user views the dashboard), Cloud Run's "scale-to-zero" capability ensures minimal cost while maintaining sub-second cold starts when auth requests arrive.
+*   **Firestore:** A flexible, scalable NoSQL cloud database. Aegis uses Firestore extensively because of its `on_snapshot` real-time listening capabilities. The local Mac agent can instantly detect when a mobile user has completed a Face ID challenge by listening to changes in a specific Firestore document without needing to repeatedly poll HTTP endpoints.
+
+## 2. Prerequisites for Deployment
+
+Before running the deployment scripts, ensure you have the following:
+
+*   A Google Cloud Project created and configured with billing enabled.
+*   The `gcloud` CLI installed and authenticated (`gcloud auth login`).
+*   The target project selected (`gcloud config set project [YOUR_PROJECT_ID]`).
+*   Docker installed locally (if building images manually, though Cloud Build handles this in the script).
+
+## 3. Environment Variables Configuration
+
+The backend requires several environment variables to function correctly. These are injected during deployment.
+
+*   `FIRESTORE_PROJECT_ID`: The ID of your GCP project where the database lives.
+*   `WEBAUTHN_RP_ID`: The Relying Party ID for WebAuthn (e.g., `aegismobile.projectalpha.in`). This must match the domain where the Mobile PWA is hosted.
+*   `WEBAUTHN_RP_NAME`: The user-friendly name of the Relying Party (e.g., `Aegis`).
+*   `WEBAUTHN_ORIGIN`: The exact origin URL of the Mobile PWA (e.g., `https://aegismobile.projectalpha.in`).
+*   `ALLOWED_ORIGINS`: A comma-separated list of CORS origins allowed to access the API (e.g., the Mac PWA, Dashboard, and Mobile PWA domains).
+
+## 4. Deployment Process
+
+Aegis provides deployment scripts to automate the build and release process. The primary script for the backend is `scripts/deploy_backend.sh`.
+
+### The `deploy_backend.sh` Script
+
+This script performs the following actions:
+
+1.  **Builds the Docker Image:** Uses `gcloud builds submit` to build the container image defined in `services/backend/Dockerfile`. The image is pushed to Google Artifact Registry.
+2.  **Deploys to Cloud Run:** Uses `gcloud run deploy` to update the service. It configures the container with the specified environment variables, sets the memory/CPU limits, allows unauthenticated access (since the API handles its own user-based auth via X-User-ID headers), and maps the port.
+
+```bash
+# Example snippet from deploy_backend.sh (conceptual)
+gcloud builds submit --tag gcr.io/[PROJECT_ID]/aegis-backend ./services/backend
+
+gcloud run deploy aegis-backend \
+  --image gcr.io/[PROJECT_ID]/aegis-backend \
+  --platform managed \
+  --region us-central1 \
+  --allow-unauthenticated \
+  --set-env-vars=FIRESTORE_PROJECT_ID=[PROJECT_ID],WEBAUTHN_RP_ID=...
+```
+
+### The Full `deploy.sh` Script
+
+The repository also includes a comprehensive `scripts/deploy.sh` script. This script orchestrates the deployment of the entire Aegis ecosystem:
+1.  **Frontend Apps:** Builds and deploys the Dashboard, Mac App, Mobile App, and Landing Page using Firebase Hosting (or a similar static hosting provider).
+2.  **Backend Services:** Triggers the backend deployment to Cloud Run.
+
+### The Dockerfile
+
+The `services/backend/Dockerfile` is standard and optimized for Python FastAPI:
+*   Uses a lightweight Python 3.10-slim base image.
+*   Installs dependencies from `requirements.txt`.
+*   Exposes port 8080 (the default for Cloud Run).
+*   Runs `uvicorn run_backend:app --host 0.0.0.0 --port $PORT` to start the server.
+
+## 5. Proof of Deployment
+
+Once deployed successfully, you can verify the service:
+
+1.  Navigate to the Cloud Run console in your GCP dashboard. You should see the `aegis-backend` service running.
+2.  Check the URL assigned to the service.
+3.  Test a basic endpoint like the health check (if configured) or verify that the frontend apps (which point to this URL via their `.env` files) can successfully reach the API.
+4.  Verify Firestore by checking the database console for the `users` collection, which should populate as users register and interact with the PWAs.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -1,0 +1,29 @@
+# Aegis: Known Limitations
+
+Aegis is a functional prototype built for the Gemini Live Agent Challenge. While it successfully demonstrates the core concept of a three-tier security model (Graduated Trust), there are several known limitations due to the nature of the hackathon sandbox and evolving architectural decisions.
+
+## 1. Google OAuth Restrictions (Gmail & Drive)
+**Limitation:** When attempting to use Aegis to read emails via Gmail, the action may fail or be blocked by Google's OAuth consent screen.
+**Reason:** This is a Google policy, not a bug in Aegis. The Aegis GCP project is currently "unverified." Google enforces strict restrictions on unverified apps requesting sensitive scopes (like `https://www.googleapis.com/auth/gmail.readonly`). Only explicitly whitelisted test accounts can grant these permissions.
+**Roadmap:** For a production release, the Aegis application would need to undergo a formal security audit and verification process by Google to remove this restriction for general users.
+
+## 2. The Shift from Composio to Native ComputerUse
+**Limitation:** The repository contains documentation (and git history) referencing "7 Composio Toolkits" (Gmail, Calendar, Docs, Sheets, Slides, Tasks, GitHub). However, the current active deployment no longer relies on Composio.
+**Reason:** We pivoted from third-party API integrations (Composio) to **Native ComputerUse** (using Gemini's vision capabilities combined with local `pyautogui` and OCR).
+*   **Why?** True agentic trust requires the agent to see what the user sees and interact with the UI directly. Relying on background API calls bypasses the visual verification step crucial for user trust. Furthermore, Native ComputerUse allows Aegis to control *any* application on the Mac, not just those with pre-built API integrations.
+**Roadmap:** We plan to refine the native execution engine, improving the reliability of `click_by_word` and visual element grounding, making third-party API wrappers entirely obsolete for basic desktop navigation.
+
+## 3. PWA vs. Native iOS Companion App
+**Limitation:** The mobile companion app (used for Face ID / RED tier authentication) is built as a Progressive Web App (PWA) rather than a native iOS app distributed via the App Store.
+**Reason:** PWAs allow for rapid, cross-platform deployment during a hackathon without the delays of App Store review. WebAuthn is fully supported in mobile Safari, allowing us to leverage the device's secure enclave (Face ID) perfectly.
+**Roadmap:** A native iOS app is planned. A native app can receive silent Apple Push Notifications (APNs) faster than a PWA polling a backend, reducing the latency between a RED action being proposed on the Mac and the Face ID prompt appearing on the iPhone.
+
+## 4. Mac Accessibility Permissions
+**Limitation:** Aegis requires extensive macOS Accessibility and Screen Recording permissions to function. If these are revoked or not granted correctly during setup, the agent cannot see or click.
+**Reason:** This is fundamental to how Native ComputerUse works on macOS.
+**Roadmap:** In a true OS-level integration (the ultimate vision for Aegis), the agent would be a trusted system daemon, and these permissions would be managed via a dedicated "Agentic Trust" preference pane rather than general accessibility settings.
+
+## 5. Vision Token Latency
+**Limitation:** Sending continuous high-resolution screenshots to the Gemini Live API consumes significant bandwidth and tokens, and introduces latency before the agent can react to visual changes.
+**Reason:** The architecture currently relies heavily on the cloud LLM to interpret the screen.
+**Roadmap:** We plan to move more visual processing (like basic element detection and bounding box extraction) to lightweight, local on-device models, using the large cloud LLM only for complex reasoning and planning. This will drastically reduce latency and token usage.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,75 @@
+# Aegis Security Model: Graduated Trust
+
+The core intellectual property of Aegis is its **Graduated Trust Security Model**. Instead of granting an AI agent blanket access to a system, Aegis introduces a dynamic trust boundary. Every proposed action is intercepted, analyzed, and classified into one of three risk tiers: **GREEN (Silent)**, **YELLOW (Confirm)**, or **RED (Biometric)**.
+
+This classification is not based merely on the tool being used, but on the *intent* and the *irreversibility* of the action.
+
+## 1. The Classifier Engine
+
+The classification logic resides in `packages/aegis/agent/classifier.py`. It uses a dedicated, secondary LLM call (Gemini 2.5 Flash) separate from the main conversation stream.
+
+Before any tool is executed, the `gate_action` function pauses the execution flow and asks the classifier to evaluate the intent.
+
+The prompt (defined in `configs/agent/prompts.yaml`) is structured strictly:
+```yaml
+CLASSIFY_WITH_HINT_PROMPT_TEMPLATE: |
+  You are a security classifier for Aegis, an AI agent controlling a Mac.
+
+  Selected tool: {tool_hint}
+  User intent: {proposed_action}
+
+  Tier rules:
+  {tier_rules_summary}
+
+  Respond ONLY with valid JSON...
+```
+
+The classifier must output the tier, a reason for its decision, and what Aegis should say to the user before proceeding.
+
+## 2. The Three Tiers (Irreversibility Criterion)
+
+The defining metric for classification is **irreversibility**. Can the user easily undo this action if the AI hallucinates or misunderstands?
+
+### 🟢 GREEN: Silent Execution (No Confirmation)
+*   **Criterion:** The action is read-only, navigational, or purely informative. It cannot alter state in a meaningful or destructive way.
+*   **Examples:** Opening an app, navigating to a URL, scrolling a page, reading screen text, taking a screenshot.
+*   **Tool Mapping:** `screen_capture`, `screen_read`, `cursor_move`, `browser_navigate`, `browser_read`, `keyboard_hotkey` (e.g., Command+Tab).
+*   **Execution:** Immediate and silent. Aegis behaves autonomously.
+
+### 🟡 YELLOW: Verbal Confirmation Required
+*   **Criterion:** The action mutates state or interacts with the UI in a way that *could* be unwanted, but is not critically destructive. It can usually be undone (e.g., deleting a character in a text box, clicking a non-committal button).
+*   **Examples:** Clicking a "Sign In" button (assuming credentials are auto-filled), typing a draft message into a text field, liking a post.
+*   **Tool Mapping:** `cursor_click`, `cursor_drag`, `keyboard_type`, `browser_click`, `browser_type`.
+*   *(Exception: If a click is purely navigational, like clicking a search result link, the classifier is instructed to downgrade it to GREEN).*
+*   **Execution:** Aegis pauses, explains its intent ("I am about to click 'Submit'"), and waits for the user to verbally say "Yes" or "Proceed" over the audio stream.
+
+### 🔴 RED: Biometric Authentication Required
+*   **Criterion:** The action is highly sensitive, destructive, or irreversible. It involves financial data, security settings, or sending communications on the user's behalf.
+*   **Examples:** Deleting files permanently (`rm -rf`), sending an email, transferring funds, revealing a saved password.
+*   **Tool Mapping:** `keyboard_type_sensitive` (a specialized tool for entering critical data), or any standard tool (`cursor_click`) if the intent is classified as destructive (e.g., clicking the final "Send" button on an email).
+*   **Execution:** Execution is hard-blocked. An out-of-band request is generated and sent to the cloud backend. The user must physically authenticate using Face ID on their companion mobile app (or Touch ID on the Mac natively).
+
+## 3. Concrete Examples
+
+Let's look at how the same underlying task (interacting with Gmail or GitHub) escalates through the tiers based on the specific action.
+
+| App / Context | Action | Classifier Tier | Why? |
+| :--- | :--- | :--- | :--- |
+| **GitHub** | *"Aegis, open my pull requests."* | **GREEN** | Purely navigational. `browser_navigate` or `cursor_click`. Undoing is just clicking 'Back'. |
+| **GitHub** | *"Aegis, write a comment saying 'LGTM'."* | **YELLOW** | State mutating. `browser_type`. The comment is drafted, but usually requires a separate click to post. Aegis asks for voice confirmation before typing. |
+| **GitHub** | *"Aegis, merge this pull request."* | **RED** | Irreversible (or difficult to reverse) and highly impactful. Even if using a simple `cursor_click` on the "Merge" button, the intent triggers a Face ID challenge. |
+| **Gmail** | *"Aegis, read the subject of the latest email."* | **GREEN** | Read-only. `screen_read`. No harm possible. |
+| **Gmail** | *"Aegis, draft a reply saying I'll be late."* | **YELLOW** | State mutating. `keyboard_type`. Creates a draft but does not send it. |
+| **Gmail** | *"Aegis, send the email."* | **RED** | Irreversible. Sending communication on behalf of the user is the highest risk action. Requires Face ID. |
+
+## 4. The Fallback Mechanism
+
+If the classifier fails to parse the Gemini response, or if the API times out, Aegis employs a strict **fail-secure** architecture.
+
+```python
+# packages/aegis/agent/classifier.py
+if not classification:
+    # Fallback to safe state
+    return {"tier": "RED", "reason": "Failed to parse classification", "upgraded": True, "speak": "I encountered an error and must block this action for safety.", "tool": None, "arguments": {}}
+```
+Any uncertainty automatically escalates the action to RED, ensuring that bugs or hallucinations cannot bypass the trust boundary.

--- a/docs/webauthn-flow.md
+++ b/docs/webauthn-flow.md
@@ -1,0 +1,80 @@
+# Aegis Biometric Authentication Flow (WebAuthn)
+
+Aegis uses WebAuthn to provide strong, out-of-band biometric authentication for "RED" (irreversible or sensitive) actions. This ensures that even if the desktop environment is compromised or the LLM hallucinates a dangerous command, the action cannot be executed without physical verification from a trusted device (like an iPhone using Face ID).
+
+## The Sequence Diagram
+
+This diagram illustrates the full flow from action proposal to verified execution.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent as Local Mac Agent (gate.py)
+    participant Classifier as Gemini Classifier
+    participant Backend as FastAPI Cloud Run
+    participant DB as Firestore
+    participant Mobile as iPhone Companion App
+
+    User->>Agent: "Delete the important file"
+    Agent->>Classifier: Classify intent
+    Classifier-->>Agent: {"tier": "RED", "reason": "Destructive command"}
+
+    note over Agent: Execution is Halted
+    Agent->>Agent: Capture visual context (screenshot crop)
+
+    Agent->>Backend: POST /auth/request (Action + Context)
+    Backend->>DB: Create "auth_requests" doc (status: pending)
+    Backend-->>Agent: request_id
+
+    note over Agent, DB: Agent polls DB /auth/status/{request_id} for 30s
+
+    note over Mobile, DB: Mobile app listens via on_snapshot for pending requests
+    DB-->>Mobile: New pending request detected
+    Mobile->>User: Displays Auth Request & Visual Context
+
+    User->>Mobile: Taps "Approve"
+
+    Mobile->>Backend: POST /webauthn/auth/options (Request Challenge)
+    Backend->>DB: Fetch user's registered public key
+    Backend-->>Mobile: WebAuthn Challenge Payload
+
+    Mobile->>User: Prompts Face ID / Touch ID
+    User-->>Mobile: Biometric Verification Success
+
+    Mobile->>Backend: POST /webauthn/auth/verify (Signed Assertion)
+    note over Backend: Verifies cryptographic signature against stored public key
+    Backend->>DB: Update "auth_requests" doc (status: approved)
+    Backend-->>Mobile: {"verified": true}
+
+    DB-->>Agent: Polling returns status: "approved"
+
+    note over Agent: Authentication Cleared
+    Agent->>Agent: Execute native screen action (pyautogui/mss)
+    Agent-->>User: "Task Complete."
+```
+
+## Step-by-Step Breakdown
+
+### 1. Detection & Context Capture (`gate.py`)
+When the `classifier.py` designates an action as RED, the `gate_action` function halts execution. It captures a downscaled screenshot crop representing the *visual context* of the proposed action (e.g., the specific file to be deleted).
+
+### 2. The Auth Request
+The local agent sends a `POST` request to the backend (`/auth/request`) containing the proposed action, the tier, the intended tool, and the visual context. The backend stores this in Firestore under the user's `auth_requests` collection with a `pending` status. The agent begins a 30-second polling loop against the backend to check the status.
+
+### 3. Mobile Notification
+The iPhone Companion App (PWA) is listening to the user's Firestore `auth_requests` collection using real-time listeners (`on_snapshot`). When it detects a new `pending` document, it alerts the user and displays the action details along with the visual context captured by the Mac.
+
+### 4. The WebAuthn Challenge (`run_backend.py`)
+If the user taps "Approve" on their phone:
+1.  The mobile app calls `POST /webauthn/auth/options`. The backend retrieves the user's previously registered WebAuthn credential ID and public key from Firestore.
+2.  The backend generates a cryptographic challenge and sends it to the phone.
+3.  The iPhone's native OS prompts the user for Face ID (or Touch ID/Passcode).
+4.  The secure enclave signs the challenge using the private key generated during initial registration.
+5.  The mobile app sends the signed assertion back via `POST /webauthn/auth/verify`.
+
+### 5. Verification and Execution
+The backend (`verify_authentication_response`) validates the signature. If valid, it updates the Firestore document status to `approved`.
+The local agent, polling the `/auth/status/{request_id}` endpoint, receives the `approved` status. It breaks out of the waiting loop and proceeds to execute the native screen action on the Mac.
+
+## Fallback Mechanism
+If the remote WebAuthn process times out (30 seconds) or fails, `gate.py` automatically falls back to requesting local Touch ID on the Mac itself using the `LocalAuthentication` framework via `pyobjc`.


### PR DESCRIPTION
Creates all necessary documentation files for the Gemini Live Agent Challenge hackathon submission as requested by the user.

Files created:
- `HACKATHON.md`: The written pitch covering the problem with autonomous agents, graduated trust insight, differences from other agents, and future vision.
- `ARCHITECTURE.md`: Deep system design detailing the local-first approach, WebSocket use, GCP components, and Gemini Live integration tradeoffs.
- `SETUP.md`: Comprehensive setup guide including prerequisites, environment variable configuration, local helper execution, and PWA integration.
- `DEMO.md`: Judge-facing demo guide with specific voice commands for testing GREEN, YELLOW, and RED actions and expectations on both the desktop UI and Mobile PWA.
- `docs/security-model.md`: Elaborates on the core IP of Green/Yellow/Red tiers based on irreversibility and classifier.py prompt structure.
- `docs/gcp-deployment.md`: Documents the GCP Cloud Run and Firestore architecture and deployment scripts.
- `docs/known-limitations.md`: Outlines honest limitations such as the Gmail read access restriction and token/bandwidth considerations.
- `docs/webauthn-flow.md`: Details the biometric auth flow featuring a Mermaid sequence diagram.
- `docs/api-reference.md`: Complete FastAPI endpoint documentation.
- `docs/composio-tools.md`: Historical explanation of the Composio toolkits integration and tier mapping before the pivot to Native ComputerUse.
- `CHANGELOG.md`: Version history derived precisely from the repository's git tags.

---
*PR created automatically by Jules for task [444300022417187594](https://jules.google.com/task/444300022417187594) started by @Harry-0318*